### PR TITLE
added handling of velocity edge-cases in the landing-position functio…

### DIFF
--- a/src/trajectories/landing_position.jl
+++ b/src/trajectories/landing_position.jl
@@ -40,6 +40,7 @@ function landing_position(x0::NTuple{3, T}, v0::NTuple{3, T};
     r, lon0, lat0 = x0
     v_esc = escape_velocity(r, T(m))
     if norm(v0) > v_esc * 0.99999; return (NaN, NaN, NaN); end
+    if norm(v0)*v0[3] <= 0; return x0; end
 
     # orbital mechanics to determine trajectory
     psi    = zenith(v0)                          # zenith angle at launch
@@ -49,7 +50,7 @@ function landing_position(x0::NTuple{3, T}, v0::NTuple{3, T};
     dtheta = 2pi - 2*_true_anomaly(e, epskin)    # true anomaly of trajectory
 
     # calculate landing position
-    sin_lat1 = sin(lat0) * cos(dtheta) + cos(lat0) * sin(dtheta) * sin(az)
+    sin_lat1 = isnan(az) ? sin(lat0) : sin(lat0) * cos(dtheta) + cos(lat0) * sin(dtheta) * sin(az)
     cos_lat1 = sqrt(1 - sin_lat1^2)
     cos_dlon = (cos(dtheta) - sin(lat0) * sin_lat1) / (cos(lat0) * cos_lat1)
 
@@ -119,6 +120,7 @@ function time_of_flight(x0::NTuple{3, T}, v0::NTuple{3, T};
     r = _getr(x0)
     v_esc = escape_velocity(r, T(m))
     if norm(v0) > v_esc; return NaN; end
+    if norm(v0)*v0[3] <= 0; return zero(T); end
 
     # orbital mechanics to determine trajectory time
     psi    = zenith(v0)                          # zenith angle at x0

--- a/test/trajectories/landing_position.jl
+++ b/test/trajectories/landing_position.jl
@@ -1,6 +1,5 @@
 using LinearAlgebra
 
-
 @testset verbose=true "landing_position.jl ........" begin
 
     print("TESTING: trajectories > landing_position.jl")
@@ -49,8 +48,9 @@ using LinearAlgebra
 
 
     #=====================================================================#
-    #::. behaviour (MC test)
+    #::. behaviour
     #=====================================================================#
+    # MC tests for accuracy / correctness
     for _ in 1:2_500
         # inputs
         x0 = rand(GlobalSphericalPosition, EqualSurfaceDistribution(LUNAR_RADIUS))
@@ -80,6 +80,19 @@ using LinearAlgebra
             @test norm(land_pos2) > LUNAR_RADIUS
         end
     end
+
+    # zero-velocity should land at launch position without throwing NaNs @ zero time-of-flight
+    @test all(x0 -> isapprox(landing_position(x0, LocalCartesianVelocity(0, 0, 0)), x0; rtol=1e-4), rand(GlobalSphericalPosition, EqualSurfaceDistribution(LUNAR_RADIUS), 1000))
+    @test all(x0 -> isapprox(time_of_flight(x0, LocalCartesianVelocity(0, 0, 0)), 0; rtol=1e-4), rand(GlobalSphericalPosition, EqualSurfaceDistribution(LUNAR_RADIUS), 1000))
+
+    # vertically upward velocity should land at launch position without throwing NaNs
+    @test all(x0 -> isapprox(landing_position(x0, LocalCartesianVelocity(0, 0, rand())), x0; rtol=1e-4), rand(GlobalSphericalPosition, EqualSurfaceDistribution(LUNAR_RADIUS), 1000))
+
+    # horizontal velocity should land at launch position without throwing NaNs @ zero time-of-flight
+    @test all(x0 -> isapprox(landing_position(x0, LocalCartesianVelocity(rand(), rand(), 0)), x0; rtol=1e-4), rand(GlobalSphericalPosition, EqualSurfaceDistribution(LUNAR_RADIUS), 1000))
+    @test all(x0 -> isapprox(time_of_flight(x0, LocalCartesianVelocity(rand(), rand(), 0)), 0; rtol=1e-4), rand(GlobalSphericalPosition, EqualSurfaceDistribution(LUNAR_RADIUS), 1000))
+
+
 
 
     println("\rTESTING: trajectories > landing_position.jl - DONE")


### PR DESCRIPTION
BUGFIX

Fixed the handling of edge cases in the launch velocity, namely:
* vertical velocity - if below the escape velocity, returns the launch position
* horizontal velocity - if below the escape velocity, does not lead to a trajectory and returns the landing position at zero time-of-flight
* zero or inwards pointing velocity - does not lead to a trajectory and returns the landing position at zero time-of-flight

The respective unit tests were also added.